### PR TITLE
Removed usages of grid-template-rows to avoid a Chrome layout bug.

### DIFF
--- a/src/components/ProjectCard.css
+++ b/src/components/ProjectCard.css
@@ -42,14 +42,12 @@ h6 {
 @media all and (max-width: 800px) {
   .project-card-content {
     grid-template-columns: 100%;
-    grid-template-rows: 100%;
   }
 }
 
 @media all and (min-width: 801px) and (max-width: 968px) {
   .project-card-content {
     grid-template-columns: 40% 30% 30%;
-    grid-template-rows: 33.33% 33.33% 33.33%;
   }
 
   .project-card-description {
@@ -60,7 +58,6 @@ h6 {
 @media all and (min-width: 969px) {
   .project-card-content {
     grid-template-columns: 34% 22% 22% 22%;
-    grid-template-rows: 50% 50%;
   }
 
   .project-card-description {


### PR DESCRIPTION
Fixes #35.

Chrome doesn't do Grid Height calculations correctly. Luckily, this was pretty easy to fix as it continues to format everything correctly without the `grid-template-rows` properties.