### PR TITLE
Remove deprecated PlayCanvas lib and add new viewer

### DIFF
--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -151,15 +151,6 @@
   "inputs" : [ "glTF 2.0" ],
   "outputs" : [ "glTF 2.0" ]
 }, {
-  "name" : "playcanvas-gltf",
-  "description" : "Adds glTF support to the PlayCanvas engine",
-  "link" : "https://github.com/playcanvas/playcanvas-gltf",
-  "task" : [ "load", "view" ],
-  "license" : [ "MIT" ],
-  "type" : [ "engine extension" ],
-  "language" : [ "JavaScript" ],
-  "inputs" : [ "glTF 2.0" ]
-}, {
   "name" : "glTFSceneKit",
   "description" : "glTF extension for Apple SceneKit",
   "link" : "https://github.com/3D4Medical/glTFSceneKit",
@@ -989,6 +980,13 @@
   "license" : [ "Multiple" ],
   "type" : [ "asset library" ],
   "inputs" : [ "Multiple", "glTF 2.0" ]
+}, {
+  "name" : "PlayCanvas glTF Viewer",
+  "description" : "Drag-and-drop online viewer for model preview and debugging, using PlayCanvas",
+  "link" : "https://playcanvas.com/viewer",
+  "task" : [ "load", "view" ],
+  "type" : [ "web application" ],
+  "inputs" : [ "glTF 2.0" ]
 }, {
   "name" : "BabylonJS Sandbox",
   "description" : "Drag-and-drop online viewer for model preview and debugging, using BabylonJS",


### PR DESCRIPTION
Recently, glTF 2.0 support has been incorporated into the core [PlayCanvas engine](https://github.com/playcanvas/engine). This renders the [playcanvas-gltf](https://github.com/playcanvas/playcanvas-gltf) repo redundant.

There is also a new, open source, online [glTF viewer](https://playcanvas.com/viewer) powered by PlayCanvas. This PR adds it to the list.