### PR TITLE
Updated Cesium projects

### DIFF
--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -1263,13 +1263,6 @@
   "inputs" : [ "COLLADA" ],
   "outputs" : [ "glTF 2.0" ]
 }, {
-  "name" : "Cesium drag-and-drop converter",
-  "description" : "Online drag and drop converter",
-  "link" : "http://cesiumjs.org/convertmodel.html",
-  "task" : [ "import", "export" ],
-  "inputs" : [ "OBJ", "COLLADA" ],
-  "outputs" : [ "glTF 2.0" ]
-}, {
   "name" : "Maya2glTF",
   "description" : "Export glTF from Autodesk Maya",
   "link" : "https://github.com/WonderMediaProductions/Maya2glTF",
@@ -1389,13 +1382,6 @@
   "type" : [ "engine" ],
   "inputs" : [ "glTF 2.0" ],
   "tags" : [ "Staff Picks" ]
-}, {
-  "name" : "Cesium glTF loader",
-  "description" : "WebGL engine\n\n[Drag-and-drop viewer](https://www.virtualgis.io/gltfviewer/), [tutorial](https://cesiumjs.org/tutorials/3D-Models-Tutorial/)",
-  "link" : "https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Scene/Model.js",
-  "task" : [ "import", "view" ],
-  "type" : [ "engine" ],
-  "inputs" : [ "glTF 2.0" ]
 }, {
   "name" : "OSG.JS glTF loader",
   "description" : "WebGL engine",
@@ -2160,5 +2146,51 @@
   "type" : [ "application" ],
   "language" : [ "c++" ],
   "inputs" : [ "glTF 2.0" ]
+}, {
+  "name": "Cesium for Unreal",
+  "link": "https://cesium.com/platform/cesium-for-unreal/",
+  "description": "A plugin for the Unreal Engine that allows streaming assets from the cloud, using the 3D Tiles format that is based on glTF",
+  "task": ["view"],
+  "type": ["plugin"],
+  "license": ["Apache-2.0"],
+  "language": ["C++"],
+  "inputs": ["3D Tiles", "glTF 2.0"]
+}, {
+  "name": "Cesium Native",
+  "link": "https://github.com/CesiumGS/cesium-native",
+  "description": "A base library for 3D geospatial applications, including lightweight glTF serialization and deserialization",
+  "task": ["load", "import", "export"],
+  "type": ["library"],
+  "license": ["Apache-2.0"],
+  "language": ["C++"],
+  "inputs": ["glTF 2.0"],
+  "outputs": ["glTF 2.0"]
+}, {
+  "name": "CesiumJS",
+  "link": "https://cesium.com/platform/cesiumjs/",
+  "description": "A library for creating geospatial web applications, and visualize data in the 3D Tiles format that is based on glTF",
+  "task": ["view"],
+  "type": ["library", "application"],
+  "license": ["Apache-2.0"],
+  "language": ["JavaScript", "TypeScript"],
+  "inputs": ["glTF 1.0", "glTF 2.0"]
+}, {
+  "name": "Cesium ion",
+  "link": "https://cesium.com/platform/cesium-ion/",
+  "description": "A platform for hosting, optimizing, and streaming massive amounts of geospatial data, using the 3D Tiles format that is based on glTF",
+  "task": ["import", "optimize"],
+  "type": ["web-api"],
+  "inputs": ["glTF 1.0", "glTF 2.0", "FBX", "CityGML", "CZML", "KML", "LAS", "LAZ", "DAE", "OBJ", "FLT", "ASC", "SRC", "TIFF", "DEM", "JPG", "PNG", "TERRAINDB"],
+  "outputs": ["3D Tiles", "glTF 2.0"]
+}, {
+  "name": "Cesium gltf-pipeline",
+  "link": "https://github.com/CesiumGS/gltf-pipeline",
+  "description": "A content pipeline for converting, optmizing, and compressing glTF assets",
+  "task": ["import", "optimize", "export"],
+  "type": ["library", "application"],
+  "license": ["Apache-2.0"],
+  "language": ["JavaScript"],
+  "inputs": ["glTF 1.0", "glTF 2.0" ],
+  "outputs": ["glTF 2.0"]
 }
 ]

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -2149,7 +2149,7 @@
 }, {
   "name": "Cesium for Unreal",
   "link": "https://cesium.com/platform/cesium-for-unreal/",
-  "description": "A plugin for the Unreal Engine that allows streaming assets from the cloud, using the 3D Tiles format that is based on glTF",
+  "description": "A plugin for the Unreal Engine that allows streaming assets from the cloud, using the 3D Tiles format that is based on glTF.",
   "task": ["view"],
   "type": ["plugin"],
   "license": ["Apache-2.0"],
@@ -2158,7 +2158,7 @@
 }, {
   "name": "Cesium Native",
   "link": "https://github.com/CesiumGS/cesium-native",
-  "description": "A base library for 3D geospatial applications, including lightweight glTF serialization and deserialization",
+  "description": "A base library for 3D geospatial applications, including lightweight glTF serialization and deserialization.",
   "task": ["load", "import", "export"],
   "type": ["library"],
   "license": ["Apache-2.0"],
@@ -2168,7 +2168,7 @@
 }, {
   "name": "CesiumJS",
   "link": "https://cesium.com/platform/cesiumjs/",
-  "description": "A library for creating geospatial web applications, and visualize data in the 3D Tiles format that is based on glTF",
+  "description": "A library for creating geospatial web applications that can load and visualize glTF assets in a geospatial context.",
   "task": ["view"],
   "type": ["library", "application"],
   "license": ["Apache-2.0"],
@@ -2177,13 +2177,13 @@
 }, {
   "name": "Cesium ion",
   "link": "https://cesium.com/platform/cesium-ion/",
-  "description": "A platform for hosting, optimizing, and streaming massive amounts of geospatial data, using the 3D Tiles format that is based on glTF",
+  "description": "A platform for hosting, optimizing, and streaming massive amounts of geospatial data. It can import glTF and other file formats, and convert them into the 3D Tiles format for efficient streaming and rendering.",
   "task": ["import", "optimize"],
   "type": ["web-api"],
   "inputs": ["glTF 1.0", "glTF 2.0", "FBX", "CityGML", "CZML", "KML", "LAS", "LAZ", "DAE", "OBJ", "FLT", "ASC", "SRC", "TIFF", "DEM", "JPG", "PNG", "TERRAINDB"],
   "outputs": ["3D Tiles", "glTF 2.0"]
 }, {
-  "name": "Cesium gltf-pipeline",
+  "name": "gltf-pipeline",
   "link": "https://github.com/CesiumGS/gltf-pipeline",
   "description": "A content pipeline for converting, optmizing, and compressing glTF assets",
   "task": ["import", "optimize", "export"],


### PR DESCRIPTION
An update for the glTF-related projects from Cesium.

TBD:

- Review the descriptions. E.g. Cesium for Unreal is not "directly" using glTF. Is the wording of *"3D Tiles ... based on glTF"* OK?
- Should links go to the website or GitHub? Right now, they go to the website for the "top-level" projects, but to GitHub for the "library" projects
- There was an entry for "Cesium glTF loader" that linked to https://github.com/CesiumGS/cesium/blob/master/Source/Scene/Model.js - I assume that this will be obsolete with the link to CesiumJS, so removed it.
- OK to mention Typescript in CesiumJS? I think so, because there now is a TypeScript definitions file
- There is an entry for https://github.com/virtualgis/gltfviewer , which is not managed by Cesium, but it is based on an old version of CesiumJS - should we trigger an update there?

@pjcozzi 

