### PR TITLE
Update projects 2021 05 05

### DIFF
--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -2217,5 +2217,44 @@
   "type": ["plugin"],
   "inputs" : [ "Multiple" ],
   "outputs": ["glTF 2.0"]
+}, {
+  "name": "Zea Engine glTF loader",
+  "link": "http://example.com",
+  "description": "The glTF loader enables loading of glTF, glTF Binary, and glTF Draco files into Zea Engine.",
+  "task": ["view", "import"],
+  "type": ["plugin"],
+  "license": ["MIT"],
+  "language": ["JavaScript"],
+  "inputs": ["glTF 2.0"]
+}, {
+  "name": "Unreal Datasmith",
+  "link": "https://www.unrealengine.com/marketplace/en-US/product/unreal-datasmith",
+  "description": "Workflow tools to import data in various formats, including glTF, into Unreal Engine.",
+  "task": ["view", "import"],
+  "type": ["plugin"],
+  "inputs": ["glTF 2.0", "3DREP", "3DXML", "ASM", "C4D", "CATPART", "CATPRODUCT", "CGR", "CREO", "DWG", "FBX", "FBX", "GLTF", "IAM", "IFC", "IGES", "IGS", "IPT", "JT", "NEU", "PLMXML", "PRT", "SAT", "SLDASM", "SLDPRT", "STEP", "STP", "UDATASMITH", "WIRE", "XML", "X_T"]
+}, {
+  "name": "Unreal glTF Exporter",
+  "link": "https://www.unrealengine.com/marketplace/en-US/product/gltf-exporter",
+  "description": "An Unreal Editor plugin that allows exporting selected actors, selected assets or a full level into glTF files.",
+  "task": ["export"],
+  "type": ["plugin"],
+  "outputs": ["glTF 2.0"]
+}, {
+  "name": "NVIDIA DesignWorks vk_raytrace sample",
+  "link": "https://github.com/nvpro-samples/vk_raytrace",
+  "description": "A glTF 2.0 sample viewer using Vulkan ray tracing, using tinygltf to load glTF 2.0 assets",
+  "task": ["view"],
+  "type": ["application", "demo"],
+  "license": ["(custom)"],
+  "language": ["C++"],
+  "inputs": ["glTF 2.0"]
+}, {
+  "name": "NVIDIA Omniverse",
+  "link": "https://docs.omniverse.nvidia.com/",
+  "description": "An editing, rendering and analysis tool, which can connect to different content creation applications, and import glTF.",
+  "task": ["view", "import", "export", "analyze"],
+  "type": ["application"],
+  "inputs": ["glTF 2.0", "Multiple"]
 }
 ]

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -307,15 +307,6 @@
   "language" : [ "TypeScript" ],
   "inputs" : [ "glTF 2.0" ]
 }, {
-  "name" : "blackthread.io",
-  "description" : "Web application for converting files to glTF, based on three.js",
-  "link" : "https://blackthread.io/gltf-converter/",
-  "task" : [ "convert" ],
-  "type" : [ "web application" ],
-  "language" : [ "JavaScript" ],
-  "inputs" : [ "3MF", "AMF", "FBX", "OBJ", "glTF 1.0", "glTF 2.0", "COLLADA", "PCD", "PLY", "STL" ],
-  "outputs" : [ "glTF 2.0" ]
-}, {
   "name" : "vectary",
   "description" : "Online application for creating 3D content",
   "link" : "https://www.vectary.com/",


### PR DESCRIPTION
An update of the projects based on the following issues:

- Fixes https://github.com/KhronosGroup/glTF-Project-Explorer/issues/84 "New Project: Zea Engine"
- Fixes https://github.com/KhronosGroup/glTF-Project-Explorer/issues/87  "New Project: Unreal Engine", and adds https://www.unrealengine.com/marketplace/en-US/product/gltf-exporter
- Fixes https://github.com/KhronosGroup/glTF-Project-Explorer/issues/89 "New Project: vk_raytrace"
- Fixes https://github.com/KhronosGroup/glTF-Project-Explorer/issues/91 "New project: NVIDIA Omniverse View"
- Fixes https://github.com/KhronosGroup/glTF-Project-Explorer/issues/90 "Blackthread.io has been taken down", removed (without replacement for now), as per request in the issue



