### PR TITLE
Fixed Zea Engine link

### DIFF
--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -2210,7 +2210,7 @@
   "outputs": ["glTF 2.0"]
 }, {
   "name": "Zea Engine glTF loader",
-  "link": "http://example.com",
+  "link": "https://github.com/ZeaInc/gltf-loader",
   "description": "The glTF loader enables loading of glTF, glTF Binary, and glTF Draco files into Zea Engine.",
   "task": ["view", "import"],
   "type": ["plugin"],


### PR DESCRIPTION
Hesitated whether to use https://github.com/ZeaInc/gltf-loader or https://docs.zea.live/gltf-loader/ , and eventually used... `example.com` - \*blushes\* this fixes the link with the one to the GitHub repo
