### PR TITLE
Update projects 2021 05 13

### DIFF
--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -2256,5 +2256,32 @@
   "language": ["JavaScript"],
   "inputs": ["Multiple", "glTF 2.0", "DAE", "FBX", "OBJ", "STP", "IGS"],
   "outputs": ["glTF 2.0","usdz"]
+}, {
+  "name": "Spark AR Studio",
+  "link": "https://sparkar.facebook.com/ar-studio/",
+  "description": "A tool for creating interactive augmented reality projects, that allows integrating glTF assets directly from [Sketchfab](https://sketchfab.com/)",
+  "task": ["view", "import"],
+  "type": ["application"],
+  "inputs": ["glTF 2.0", "FBX", "DAE", "OBJ"]
+}, {
+  "name": "Asobo Studio - Microsoft Flight Simulator glTF Exporter for 3ds Max",
+  "link": "https://github.com/AsoboStudio/FlightSim-glTF-exporter",
+  "description": "A fork of the BabylonJS 3ds Max exporter that exports glTF assets for the Microsoft Flight Simulator, using materials that are based on the Asobo glTF extensions",
+  "task": ["export"],
+  "type": ["plugin"],
+  "license": ["Apache-2.0"],
+  "language": ["C#"],
+  "inputs": ["Multiple"],
+  "outputs": ["glTF 2.0"]
+}, {
+  "name": "Blender2MSFS toolkit",
+  "link": "https://www.fsdeveloper.com/wiki/index.php?title=Blender2MSFS",
+  "description": "A Blender addon for creating glTF assets for the Microsoft Flight Simulator",
+  "task": ["export"],
+  "type": ["plugin"],
+  "license": ["Apache-2.0"],
+  "language": ["Python"],
+  "inputs": ["Multiple"],
+  "outputs": ["glTF 2.0"]
 }
 ]


### PR DESCRIPTION
An update of the projects based on the following issues:

- Fixes https://github.com/KhronosGroup/glTF-Project-Explorer/issues/86 : "New Project: Facebook Spark AR Studio"
- Might fix https://github.com/KhronosGroup/glTF-Project-Explorer/issues/93 : "New Project: Microsoft FlightSim"

For the Flight Simulator-related projects:

Maybe @elpie89 wants to see whether the wording is appropriate. I didn't dive too deeply into the technicalities of these projects. E.g. there does not seem to be a GitHub repo for the "Blender2MSFS" one (yet?). 

@pjcozzi You suggested adding *"FlightSim runtime itself"* in issue 93. I can see the reasoning. It may be one of the largest and most broadly visible applications of glTF until now. But it's a slippery slope: When the use of glTF becomes broader (in applications and games), we'd have to consider where to draw the line, and how to deal with requests from developers to ~"add their project, because it also uses glTF". I can add it, if it is explicitly requested, but we should keep that in mind...
