### PR TITLE
Fixed duplicate FBX entry for Unreal Datasmith

### DIFF
--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -2231,7 +2231,7 @@
   "description": "Workflow tools to import data in various formats, including glTF, into Unreal Engine.",
   "task": ["view", "import"],
   "type": ["plugin"],
-  "inputs": ["glTF 2.0", "3DREP", "3DXML", "ASM", "C4D", "CATPART", "CATPRODUCT", "CGR", "CREO", "DWG", "FBX", "FBX", "GLTF", "IAM", "IFC", "IGES", "IGS", "IPT", "JT", "NEU", "PLMXML", "PRT", "SAT", "SLDASM", "SLDPRT", "STEP", "STP", "UDATASMITH", "WIRE", "XML", "X_T"]
+  "inputs": ["glTF 2.0", "3DREP", "3DXML", "ASM", "C4D", "CATPART", "CATPRODUCT", "CGR", "CREO", "DWG", "FBX", "GLTF", "IAM", "IFC", "IGES", "IGS", "IPT", "JT", "NEU", "PLMXML", "PRT", "SAT", "SLDASM", "SLDPRT", "STEP", "STP", "UDATASMITH", "WIRE", "XML", "X_T"]
 }, {
   "name": "Unreal glTF Exporter",
   "link": "https://www.unrealengine.com/marketplace/en-US/product/gltf-exporter",


### PR DESCRIPTION
I found a duplicate entry of FBX for Unreal Datasmith. This isn't really ideal for the search stuff I'm working on, so I'm fixing it. I have played around with the idea of how we can add a guard, but adding a filter for unique items adds another loop to the process that _every_ card has to go through and since this seems to be the only case of this we've ever gotten, I'm not keen to do so at this time. It's easy to fix the data and could have performance impacts if we try to add the guard.