### PR TITLE
Project data cleanup 2022 07 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Tool to provide a filterable registry of glTF community projects.
 
-http://github.khronos.org/glTF-Project-Explorer/
+https://github.khronos.org/glTF-Project-Explorer/
 
 ## Contributions
 

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -1564,7 +1564,7 @@
 }, {
   "name" : "UX3D Engine",
   "description" : "Cross-platform multi-threaded Vulkan 3D Engine with glTF 2.0 import and export",
-  "link" : "https://www.ux3d.io/",
+  "link" : "http://www.ux3d.io/",
   "language" : [ "C++" ],
   "inputs" : [ "glTF 2.0" ]
 }, {

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -1722,7 +1722,7 @@
 }, {
   "name" : "Facebook",
   "description" : "Use .glb files to create 3D Posts",
-  "link" : "https://developers.facebook.com/docs/sharing/3d-posts",
+  "link" : "https://developers.facebook.com/blog/post/2018/02/20/3d-posts-facebook/",
   "type" : [ "application" ]
 }, {
   "name" : "Sketchfab",

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -1341,7 +1341,7 @@
 }, {
   "name" : "Cinema 4D Exporter",
   "description" : "Export glTF from MAXON Cinema 4D",
-  "link" : "https://labs.maxon.net/?p=3360",
+  "link" : "https://www.maxon.net/en/cinema-4d/integration/file-exchange",
   "task" : [ "import", "export" ],
   "inputs" : [ "Multiple" ],
   "outputs" : [ "glTF 2.0" ]

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -254,7 +254,7 @@
 }, {
   "name" : "Unbound.io",
   "description" : "Content creation with glTF export",
-  "link" : "http://unbound.io/",
+  "link" : "https://unbound.io/",
   "task" : [ "view", "export" ],
   "type" : [ "application" ],
   "outputs" : [ "glTF 2.0" ]
@@ -334,7 +334,7 @@
   "inputs" : [ "glTF 2.0" ]
 }, {
   "name" : "SOLIDWORKS",
-  "description" : "CAD application with option for glTF export\n\nExport described at http://help.solidworks.com/2019/english/SolidWorks/sldworks/t_export_using_extended_reality.htm",
+  "description" : "CAD application with option for glTF export\n\nExport described at https://help.solidworks.com/2019/english/SolidWorks/sldworks/t_export_using_extended_reality.htm",
   "link" : "https://www.solidworks.com",
   "task" : [ "export" ],
   "type" : [ "application" ],
@@ -692,7 +692,7 @@
 }, {
   "name" : "AGI Systems Tool Kit",
   "description" : "Modeling environment",
-  "link" : "http://www.agi.com/products",
+  "link" : "https://www.agi.com/products",
   "task" : [ "import" ],
   "type" : [ "application" ],
   "inputs" : [ "glTF 2.0" ]
@@ -731,7 +731,7 @@
   "outputs" : [ "Multiple", "glTF 2.0" ]
 }, {
   "name" : "BIMData.io",
-  "description" : "Tool to deal with IFC files\n\nViewer at http://bimsurfer.org/",
+  "description" : "Tool to deal with IFC files\n\nViewer at https://bimsurfer.org/",
   "link" : "https://bimdata.io/",
   "task" : [ "import", "view" ],
   "type" : [ "web api" ],
@@ -825,7 +825,7 @@
 }, {
   "name" : "Noesis",
   "description" : "A tool for converting between model file formats",
-  "link" : "http://richwhitehouse.com/index.php?content=inc_projects.php&showproject=91",
+  "link" : "https://richwhitehouse.com/index.php?content=inc_projects.php&showproject=91",
   "task" : [ "import", "view", "export" ],
   "type" : [ "application" ],
   "inputs" : [ "Multiple", "glTF 2.0" ],
@@ -848,7 +848,7 @@
 }, {
   "name" : "Xiratech Module Viewer",
   "description" : "A viewer for a (fixed?) glTF asset",
-  "link" : "http://www.pasamson.net/",
+  "link" : "https://www.pasamson.net/",
   "task" : [ "view" ],
   "type" : [ "web application" ],
   "inputs" : [ "glTF 2.0" ]
@@ -985,7 +985,7 @@
 }, {
   "name" : "three.js Editor",
   "description" : "Editor with drag-and-drop support",
-  "link" : "http://threejs.org/editor",
+  "link" : "https://threejs.org/editor",
   "task" : [ "load", "view" ],
   "type" : [ "web application" ],
   "inputs" : [ "glTF 2.0" ]
@@ -1062,7 +1062,7 @@
 }, {
   "name" : "Khronos glTF Sample Viewer",
   "description" : "Engine-agnostic sample viewer with WebGL PBR shader for glTF 2.0 ([source code](https://github.com/KhronosGroup/glTF-Sample-Viewer))",
-  "link" : "http://github.khronos.org/glTF-Sample-Viewer/",
+  "link" : "https://github.khronos.org/glTF-Sample-Viewer/",
   "task" : [ "load", "view" ],
   "type" : [ "web application" ],
   "inputs" : [ "glTF 2.0" ],
@@ -1076,7 +1076,7 @@
 }, {
   "name" : "gltf-enum",
   "description" : "Simple site to help work with all the different enums in glTF spec",
-  "link" : "http://gltf-enum.com/",
+  "link" : "https://gltf-enum.com/",
   "type" : [ "website" ],
   "inputs" : [ "glTF 2.0" ]
 }, {
@@ -1137,15 +1137,15 @@
   "tags" : [ "Khronos Official" ]
 }, {
   "name" : "3DS Max Exporter",
-  "description" : "Export glTF files using [BabylonJS plugin](http://doc.babylonjs.com/resources/3dsmax#how-to-install-the-3ds-max-plugin) for 3DS Max 2015 or later",
-  "link" : "http://doc.babylonjs.com/resources/3dsmax_to_gltf",
+  "description" : "Export glTF files using [BabylonJS plugin](https://doc.babylonjs.com/resources/3dsmax#how-to-install-the-3ds-max-plugin) for 3DS Max 2015 or later",
+  "link" : "https://doc.babylonjs.com/resources/3dsmax_to_gltf",
   "task" : [ "import", "export" ],
   "inputs" : [ "Multiple" ],
   "outputs" : [ "glTF 2.0" ]
 }, {
   "name" : "Maya Exporter",
-  "description" : "Export glTF files using [BabylonJS plugin](http://doc.babylonjs.com/resources/maya) for Maya 2018 or later",
-  "link" : "http://doc.babylonjs.com/resources/maya_to_gltf",
+  "description" : "Export glTF files using [BabylonJS plugin](https://doc.babylonjs.com/resources/maya) for Maya 2018 or later",
+  "link" : "https://doc.babylonjs.com/resources/maya_to_gltf",
   "task" : [ "import", "export" ],
   "inputs" : [ "Multiple" ],
   "outputs" : [ "glTF 2.0" ]
@@ -1159,7 +1159,7 @@
 }, {
   "name" : "import",
   "description" : "Separate extensions for export and import",
-  "link" : "http://extensions.sketchup.com/en/content/gltf-import",
+  "link" : "https://extensions.sketchup.com/en/content/gltf-import",
   "task" : [ "import", "export" ],
   "inputs" : [ "Multiple" ],
   "outputs" : [ "glTF 2.0" ]
@@ -1194,7 +1194,7 @@
 }, {
   "name" : "Assimp",
   "description" : "General-purpose online conversion pipeline",
-  "link" : "http://www.assimp.org/",
+  "link" : "https://www.assimp.org/",
   "task" : [ "import", "export" ],
   "inputs" : [ "3D", "3DS", "3MF", "AC", "AC3D", "ACC", "AMJ", "ASE", "ASK", "B3D", "BLEND", "BVH", "CMS", "COB", "COLLADA", "DXF", "ENFF", "FBX", "glTF 1.0", "glTF 2.0", "HMB", "IFC-STEP", "IRR", "LWO", "LWS", "LXO", "M3D", "MD2", "MD3", "MD5", "MDC", "MDL", "MESH", "MOT", "MS3D", "NDO", "NFF", "OBJ", "OFF", "OGEX", "PLY", "PMX", "PRJ", "Q3O", "Q3S", "RAW", "SCN", "SIB", "SMD", "STP", "STL", "TER", "UC", "VTA", "X", "X3D", "XGL", "ZGL" ],
   "outputs" : [ "DAE", "STL", "OBJ", "PLY", "X", "3DS", "ASSBIN", "STEP", "glTF 1.0", "glTF 2.0", "3MF", "FBX"  ]
@@ -1229,7 +1229,7 @@
 }, {
   "name" : "Verge3D",
   "description" : "WebGL engine with [glTF loader](https://www.soft8soft.com/docs/examples/loaders/GLTFLoader.html). [Examples](https://www.soft8soft.com/gallery/)",
-  "link" : "http://www.soft8soft.com/verge3d/",
+  "link" : "https://www.soft8soft.com/verge3d/",
   "task" : [ "import", "view", "export" ],
   "type" : [ "engine" ],
   "inputs" : [ "Multiple", "glTF 2.0" ]
@@ -1319,7 +1319,7 @@
   "outputs" : [ "Multiple", "glTF 2.0" ]
 }, {
   "name" : "UModel (UE Viewer)",
-  "description" : "UModel allows you to view static and animated mesh assets from [Unreal engine games](http://www.gildor.org/projects/umodel/compat), and then export them into several formats including glTF 2.0",
+  "description" : "UModel allows you to view static and animated mesh assets from [Unreal engine games](https://www.gildor.org/projects/umodel/compat), and then export them into several formats including glTF 2.0",
   "link" : "https://github.com/gildor2/UModel",
   "task" : [ "import", "export" ],
   "inputs" : [ "Unreal engine" ],
@@ -1382,7 +1382,7 @@
   "inputs" : [ "glTF 2.0" ]
 }, {
   "name" : "BabylonJS glTF loader",
-  "description" : "WebGL engine\n\n[Viewer component](http://doc.babylonjs.com/extensions/the_babylon_viewer)",
+  "description" : "WebGL engine\n\n[Viewer component](https://doc.babylonjs.com/extensions/the_babylon_viewer)",
   "link" : "https://github.com/BabylonJS/Babylon.js/tree/master/loaders/src/glTF",
   "task" : [ "import", "view" ],
   "type" : [ "engine" ],
@@ -1418,15 +1418,15 @@
   "inputs" : [ "glTF 2.0" ]
 }, {
   "name" : "xeogl glTF loader",
-  "description" : "WebGL engine\n\n[Tutorial](http://xeogl.org/docs/classes/GLTFModel.html)",
-  "link" : "http://xeogl.org/examples/#importing_gltf_BoomBox",
+  "description" : "WebGL engine\n\n[Tutorial](https://xeogl.org/docs/classes/GLTFModel.html)",
+  "link" : "https://xeogl.org/examples/#importing_gltf_BoomBox",
   "task" : [ "import", "view" ],
   "type" : [ "engine" ],
   "inputs" : [ "glTF 2.0" ]
 }, {
   "name" : "ClayGL glTF loader",
-  "description" : "WebGL engine\n\n[Examples](http://examples.claygl.xyz/)",
-  "link" : "http://docs.claygl.xyz/api/clay.application.App3D.html#loadModel",
+  "description" : "WebGL engine\n\n[Examples](https://examples.claygl.xyz/)",
+  "link" : "https://docs.claygl.xyz/api/clay.application.App3D.html#loadModel",
   "task" : [ "import", "view" ],
   "type" : [ "engine" ],
   "inputs" : [ "glTF 2.0" ]
@@ -1439,7 +1439,7 @@
   "inputs" : [ "glTF 2.0" ]
 }, {
   "name" : "CZPG glTF loader",
-  "description" : "WebGL engine\n\n[Examples](http://princessgod.github.io/CraZyPG)",
+  "description" : "WebGL engine\n\n[Examples](https://princessgod.github.io/CraZyPG)",
   "link" : "https://github.com/PrincessGod/CraZyPG/blob/master/src/loaders/GLTFLoader.js",
   "task" : [ "import", "view" ],
   "type" : [ "engine" ],
@@ -1560,7 +1560,7 @@
 }, {
   "name" : "Qt 3D",
   "description" : "Qt 3D provides functionality for near-realtime simulation systems",
-  "link" : "http://doc.qt.io/qt-5.6/qt3d-gltf-example.html",
+  "link" : "https://doc.qt.io/qt-5.6/qt3d-gltf-example.html",
   "language" : [ "C++" ],
   "inputs" : [ "glTF 2.0" ]
 }, {
@@ -1584,7 +1584,7 @@
 }, {
   "name" : "Cinder",
   "description" : "Work-in-progress glTF importer",
-  "link" : "http://discourse.libcinder.org/t/gltf-initial-release-wip/212",
+  "link" : "https://discourse.libcinder.org/t/gltf-initial-release-wip/212",
   "language" : [ "C++" ],
   "inputs" : [ "glTF 1.0" ]
 }, {
@@ -1635,7 +1635,7 @@
 }, {
   "name" : "Aspose.3D for .NET",
   "description" : "Import, export, and convert glTF",
-  "link" : "http://www.aspose.com/products/3d/net",
+  "link" : "https://www.aspose.com/products/3d/net",
   "language" : [ "C#" ],
   "inputs" : [ "glTF 2.0" ]
 }, {
@@ -1771,7 +1771,7 @@
 }, {
   "name" : "3D Slash",
   "description" : "Web-based and app-based 3D modeling imitating a stonecutter",
-  "link" : "http://www.3dslash.net",
+  "link" : "https://www.3dslash.net",
   "type" : [ "application" ]
 }, {
   "name" : "Archilogic",
@@ -1841,7 +1841,7 @@
 }, {
   "name" : "jMonkeyEngine",
   "description" : "jME 3.2 supports glTF 2.0",
-  "link" : "http://jmonkeyengine.org/",
+  "link" : "https://jmonkeyengine.org/",
   "type" : [ "engine" ],
   "inputs" : [ "glTF 2.0" ]
 }, {

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -533,9 +533,9 @@
   "language" : [ "JavaScript" ],
   "inputs" : [ "glTF 2.0" ]
 }, {
-  "name" : "Wave Engine",
+  "name" : "Evergine",
   "description" : "Cross-Platform graphics engine and authoring tool with glTF support\n\nglTF support announced in https://geeks.ms/waveengineteam/2018/07/03/model_workflow/",
-  "link" : "https://waveengine.net/",
+  "link" : "https://evergine.com/",
   "task" : [ "import", "view" ],
   "type" : [ "application" ],
   "inputs" : [ "glTF 2.0" ]

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -948,10 +948,10 @@
   "inputs" : [ "Multiple", "glTF 2.0" ]
 }, {
   "name" : "EF EVE",
-  "description" : "3D asset library\n\nglTF assets at https://ef-eve.com/platform/?filterformat=gltf",
-  "link" : "https://ef-eve.com/platform",
+  "description" : "Volumetric video editor\n\nglTF assets at https://ef-eve.com/help-center/obj-with-texutres-to-gltf-or-glb/",
+  "link" : "https://ef-eve.com",
   "license" : [ "Multiple" ],
-  "type" : [ "asset library" ],
+  "type" : [ "application" ],
   "inputs" : [ "Multiple", "glTF 2.0" ]
 }, {
   "name" : "PlayCanvas glTF Viewer",
@@ -997,8 +997,8 @@
   "inputs" : [ "glTF 2.0" ]
 }, {
   "name" : "VirtualGIS Viewer",
-  "description" : "Cesium-based glTF viewer.",
-  "link" : "https://www.virtualgis.io/gltfviewer/",
+  "description" : "Geospatial application platform with a Cesium-based viewer that supports glTF",
+  "link" : "https://www.virtualgis.io/",
   "task" : [ "load", "view" ],
   "type" : [ "web application" ],
   "inputs" : [ "glTF 2.0" ]

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -1797,23 +1797,23 @@
   "name" : "Babylon.js Viewer",
   "description" : "HTML web component for viewing self-hosted glTF models.",
   "link" : "https://doc.babylonjs.com/extensions/the_babylon_viewer",
-  "type" : [ "viewer, embeddable, self-hosted" ]
+  "type" : [ "viewer", "embeddable", "self-hosted" ]
 }, {
   "name" : "<model-viewer>",
   "description" : "HTML web component for viewing self-hosted glTF models.",
   "link" : "https://github.com/GoogleWebComponents/model-viewer",
-  "type" : [ "viewer, embeddable, self-hosted" ]
+  "type" : [ "viewer", "embeddable", "self-hosted" ]
 }, {
   "name" : "Poly",
   "description" : "glTF models hosted on Poly may be embedded in an iframe on any site.",
   "link" : "https://poly.google.com/",
   "task" : [ "service" ],
-  "type" : [ "viewer, embeddable, self-hosted" ]
+  "type" : [ "viewer", "embeddable", "self-hosted" ]
 }, {
   "name" : "Sketchfab",
   "description" : "glTF models hosted on Sketchfab may be embedded in an iframe on any site, using the [embed models](https://help.sketchfab.com/hc/en-us/articles/203509907-Embed-Models) feature.",
   "link" : "https://sketchfab.com/",
-  "type" : [ "viewer, embeddable, service" ]
+  "type" : [ "viewer", "embeddable", "service" ]
 }, {
   "name" : "UnityGLTF",
   "description" : "Unity3D library for exporting, loading, parsing, and rendering glTF assets",

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -1026,7 +1026,7 @@
 }, {
   "name" : "glTFShowcase",
   "description" : "Android and iOS app for viewing glTF 2.0 asset from local files (gltf/glb/zip): supports environment lighting change.",
-  "link" : "https://www.vispolygon.com/",
+  "link" : "https://play.google.com/store/apps/details?id=com.vispolygon.gltfshowcase.alpha",
   "task" : [ "load", "view" ],
   "type" : [ "web application" ],
   "inputs" : [ "glTF 2.0" ]

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -1744,10 +1744,10 @@
   "link" : "https://blog.sketchfab.com/sketchfab-now-supports-gltf/",
   "type" : [ "application" ]
 }, {
-  "name" : "Wordpress",
+  "name" : "Wordpress 3D Viewer Plugin",
   "description" : "Inline glTF renderer for WordPress",
-  "link" : "plugin",
-  "type" : [ "application" ]
+  "link": "https://wordpress.org/plugins/3d-viewer/",
+  "type" : [ "plugin" ]
 }, {
   "name" : "Modo",
   "description" : "3D modeling, texturing & rendering tools",

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -578,8 +578,8 @@
   "outputs" : [ "USDZ" ]
 }, {
   "name" : "Speedernet Sphere",
-  "description" : "Virtual Reality software with glTF support\n\nDetails at https://sphereapp.io/speedernet-sphere-create-webvr-solidworks-gltf/",
-  "link" : "https://sphereapp.io/",
+  "description" : "Virtual Reality software with glTF support",
+  "link" : "https://speedernet-sphere.com/",
   "task" : [ "import", "view" ],
   "type" : [ "application" ],
   "inputs" : [ "glTF 2.0" ]

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -1369,7 +1369,7 @@
 }, {
   "name" : "BabylonJS glTF loader",
   "description" : "WebGL engine\n\n[Viewer component](https://doc.babylonjs.com/extensions/the_babylon_viewer)",
-  "link" : "https://github.com/BabylonJS/Babylon.js/tree/master/loaders/src/glTF",
+  "link" : "https://github.com/BabylonJS/Babylon.js/tree/master/packages/dev/loaders/src/glTF",
   "task" : [ "import", "view" ],
   "type" : [ "engine" ],
   "inputs" : [ "glTF 2.0" ],

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -168,14 +168,6 @@
   "language" : [ "C++" ],
   "inputs" : [ "Multiple" ]
 }, {
-  "name" : "Google Poly API",
-  "description" : "An API to access 3D assets",
-  "link" : "https://blog.google/products/poly/introducing-poly-api/",
-  "task" : [ "load" ],
-  "type" : [ "web api" ],
-  "language" : [ "REST" ],
-  "inputs" : [ "glTF 2.0" ]
-}, {
   "name" : "Insimo glTF tools",
   "description" : "Tools built on top of a glTF viewer\n\nTools in online viewer at https://gltf.insimo.com/",
   "link" : "https://github.com/InSimo/three-gltf-viewer/tree/tools/tools",

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -493,9 +493,9 @@
   "language" : [ "C++" ],
   "inputs" : [ "glTF 2.0" ]
 }, {
-  "name" : "MeshroomVR",
+  "name" : "WEWIZ",
   "description" : "3D visualization software",
-  "link" : "https://meshroomvr.com/",
+  "link" : "https://weviz.com/",
   "task" : [ "import", "view" ],
   "type" : [ "application" ],
   "inputs" : [ "Multiple", "glTF 2.0" ]

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -1556,7 +1556,7 @@
 }, {
   "name" : "UX3D Engine",
   "description" : "Cross-platform multi-threaded Vulkan 3D Engine with glTF 2.0 import and export",
-  "link" : "http://www.ux3d.io/",
+  "link" : "https://www.ux3d.io/",
   "language" : [ "C++" ],
   "inputs" : [ "glTF 2.0" ]
 }, {

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -1417,9 +1417,9 @@
   "type" : [ "engine" ],
   "inputs" : [ "glTF 2.0" ]
 }, {
-  "name" : "React 360",
+  "name" : "React 360 (archived)",
   "description" : "WebGL engine",
-  "link" : "https://facebook.github.io/react-360/",
+  "link" : "https://github.com/facebookarchive/react-360",
   "task" : [ "import", "view" ],
   "type" : [ "engine" ],
   "inputs" : [ "glTF 2.0" ]

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -1411,8 +1411,8 @@
   "inputs" : [ "glTF 2.0" ]
 }, {
   "name" : "ClayGL glTF loader",
-  "description" : "WebGL engine\n\n[Examples](https://examples.claygl.xyz/)",
-  "link" : "https://docs.claygl.xyz/api/clay.application.App3D.html#loadModel",
+  "description" : "WebGL engine\n\n[Examples](http://examples.claygl.xyz/)",
+  "link" : "http://docs.claygl.xyz/api/clay.application.App3D.html#loadModel",
   "task" : [ "import", "view" ],
   "type" : [ "engine" ],
   "inputs" : [ "glTF 2.0" ]

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -1454,7 +1454,7 @@
 }, {
   "name" : "X3DOM glTF loader",
   "description" : "WebGL engine",
-  "link" : "https://github.com/x3dom/x3dom/blob/master/src/util/glTF/glTFLoader.js",
+  "link" : "https://github.com/x3dom/x3dom/tree/master/src/util/glTF",
   "task" : [ "import", "view" ],
   "type" : [ "engine" ],
   "inputs" : [ "glTF 1.0" ]

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -780,14 +780,6 @@
   "language" : [ "TypeScript" ],
   "inputs" : [ "glTF 2.0" ]
 }, {
-  "name" : "point105ar",
-  "description" : "Online converter with glTF output",
-  "link" : "https://www.point105ar.com/",
-  "task" : [ "convert" ],
-  "type" : [ "web-application" ],
-  "inputs" : [ "Multiple" ],
-  "outputs" : [ "glTF 2.0, USDZ" ]
-}, {
   "name" : "The Wild",
   "description" : "VR/AR collaboration platform",
   "link" : "https://thewild.com/",

--- a/public/data/glTF-projects-data.json
+++ b/public/data/glTF-projects-data.json
@@ -1066,12 +1066,6 @@
   "type" : [ "application" ],
   "inputs" : [ "glTF 2.0" ]
 }, {
-  "name" : "gltf-enum",
-  "description" : "Simple site to help work with all the different enums in glTF spec",
-  "link" : "https://gltf-enum.com/",
-  "type" : [ "website" ],
-  "inputs" : [ "glTF 2.0" ]
-}, {
   "name" : "gltf-import-export",
   "description" : "NPM package to convert between glb and gltf files",
   "link" : "https://github.com/najadojo/gltf-import-export",


### PR DESCRIPTION
- Cleaned up the entries that had things like `"viewer, embeddable, self-hosted"` as their `type` to use these words as individual strings
- Updated the live-link in the README to use HTTP**S**
  - During that: noticed that many entries use HTTP instead of HTTPS
- Changed all the links to use HTTPS by default
  - Noticed that some of these entries are actually dead links
    - Wrote a tool that reads the projects data JSON and tries to contact all links, to see whether they are 404
      - Noticed that I'm in a rabbit hole...
      - Ignored that...
- Fixed several links and descriptions that caused 404's or have otherwise been outdated...


I guess somebody _has_ to do something like this, occasionally. It still raises the question about how such "maintenance" can be done for larger project databases. E.g. one of the links led to some dubious site that smelled like malware for me, so I just removed it. Other entries may be outdated in other ways (even if the link is not a 404). But that probably has to be sorted out elsewhere.


