### PR TITLE
Use ProjectProperties in ProjectCard

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,4 +1,4 @@
-import { IProjectInfo } from "../interfaces/IProjectInfo";
+import { IProjectInfo, ProjectProperties } from "../interfaces/IProjectInfo";
 import ProjectDetailList from "./ProjectDetailList";
 import ProjectCardHeader from "./ProjectCardHeader";
 import "./ProjectCard.css";
@@ -12,7 +12,6 @@ interface IProjectCardProps {
 
 const ProjectCard: React.FC<IProjectCardProps> = (props) => {
   const { project } = props;
-
   return (
     <div className="project-card m-4 rounded p-4 shadow-sharp transition ease-in-out hover:shadow-hover">
       <ProjectCardHeader project={project} />
@@ -24,30 +23,17 @@ const ProjectCard: React.FC<IProjectCardProps> = (props) => {
           />
         )}
         <div className="grid gap-4 md:grid-cols-3 lg:col-span-2 lg:grid-cols-4">
-          {shouldShowSection(project.task) && (
-            <ProjectDetailList header="Task" items={project.task} />
-          )}
-          {shouldShowSection(project.license) && (
-            <ProjectDetailList header="License" items={project.license} />
-          )}
-          {shouldShowSection(project.language) && (
-            <ProjectDetailList
-              header="Supported Languages"
-              items={project.language!}
-            />
-          )}
-          {shouldShowSection(project.type) && (
-            <ProjectDetailList header="Type" items={project.type} />
-          )}
-          {shouldShowSection(project.inputs) && (
-            <ProjectDetailList header="Input Methods" items={project.inputs} />
-          )}
-          {shouldShowSection(project.outputs) && (
-            <ProjectDetailList
-              header="Output Methods"
-              items={project.outputs}
-            />
-          )}
+          {Object.keys(project.properties).map((propName) => {
+            const items = project.properties[propName];
+            return (
+              shouldShowSection(items) && (
+                <ProjectDetailList
+                  header={`${ProjectProperties.get(propName)}`}
+                  items={items}
+                />
+              )
+            );
+          })}
         </div>
       </div>
     </div>

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -28,6 +28,7 @@ const ProjectCard: React.FC<IProjectCardProps> = (props) => {
             return (
               shouldShowSection(items) && (
                 <ProjectDetailList
+                  key={propName}
                   header={`${ProjectProperties.get(propName)}`}
                   items={items}
                 />

--- a/src/interfaces/IAppState.ts
+++ b/src/interfaces/IAppState.ts
@@ -29,7 +29,7 @@ export interface IProjectsState {
 /**
  * The part of the state that summarizes the filter options and selection.
  *
- * @property filterOptions A record that maps ProjectProperties values to the
+ * @property filterOptions A record that maps ProjectProperties keys to the
  * list of filters that are available for this project property. These are
  * one filter object for each possible value of this property.
  * @property titleSubstring The string that was entered in the free-text search box

--- a/src/interfaces/IProjectInfo.ts
+++ b/src/interfaces/IProjectInfo.ts
@@ -22,22 +22,22 @@ type ProjectTag = string;
  */
 
 /**
- * The set of keys for the IProjectInfo#properties map
+ * The map of keys for the IProjectInfo#properties map,
+ * mapped to a human-readable form that is shown in the UI
  */
-export const ProjectProperties: Set<string> = new Set<string>([
-  "task",
-  "license",
-  "type",
-  "language",
-  "inputs",
-  "outputs",
-  "tags",
+export const ProjectProperties = new Map<string, string>([
+  ["task", "Task"],
+  ["license", "License"],
+  ["type", "Type"],
+  ["language", "Language"],
+  ["inputs", "Inputs"],
+  ["outputs", "Outputs"],
+  ["tags", "Tags"],
 ]);
 
 /**
  * A map defining the ProjectProperties by which the projects
- * can be filtered. The keys are the ProjectProperties elements.
- * The values are the string for the UI.
+ * can be filtered, which is a subset of the ProjectProperties 
  */
 export const ProjectFilterProperties = new Map<string, string>([
   ["tags", "Tags"],

--- a/src/store/filters/Interfaces.ts
+++ b/src/store/filters/Interfaces.ts
@@ -11,7 +11,7 @@ export type FiltersActions =
  * only called ONCE (?).
  *
  * The `filterOptions` are in fact the options for the filters. It is a
- * map that maps ProjectProperties values (i.e. the keys of the
+ * map that maps ProjectProperties keys (i.e. the keys of the
  * IProjectInfo#properties map) to the filters that have been created
  * for the respective property for ALL available projects.
  *


### PR DESCRIPTION
As mentioned in https://github.com/KhronosGroup/glTF-Project-Explorer/issues/151#issuecomment-1267485047 : The `ProjectCart.tsx` that displays the actual UI element for each project still used the hard-wired `task/type/inputs...` properties of the `IProjectInfo`. This has been changed to use the general properties that are defined via `ProjectProperties` now.
