### PR TITLE
Fix build issues related to Node and GLIBC versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os: linux
 dist: xenial
 node_js:
-  - 12
+  - 14
 language: node_js
 script:
   - yarn build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 os: linux
 dist: xenial
+node_js:
+  - 16
 language: node_js
 script:
   - yarn build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os: linux
 dist: xenial
 node_js:
-  - 16
+  - 12
 language: node_js
 script:
   - yarn build


### PR DESCRIPTION
Trying to fix the travis build, which was recently failing with
`node: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.28' not found (required by node)`

Some guesses here: 

It probably tries to install the latest (LTS?) version of node, which is now 18, and which needs GLIBC with a version that is _higher_ than the one that is currently installed with the `xenial` distribution. According to https://docs.travis-ci.com/user/reference/xenial/#javascript-and-nodejs-support , the latest supported Node version in xenial is 12. So I'm giving that a try...
