### PR TITLE
Fix ref that triggers depolyoment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
         run: yarn build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/head/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build


### PR DESCRIPTION
Referring to https://github.com/KhronosGroup/glTF-Project-Explorer/issues/161#issuecomment-1470758958 , I think the condition for the deployment to be run was wrong:
```
if: ${{ github.ref == 'refs/head/main' }}    // OLD
if: ${{ github.ref == 'refs/heads/main' }}   // NEW
```
@weegeekps If that looks about right, feel free to merge.



